### PR TITLE
Add commands to telegram plugin

### DIFF
--- a/.changeset/two-pumas-serve.md
+++ b/.changeset/two-pumas-serve.md
@@ -1,0 +1,5 @@
+---
+'@tribesxyz/ayaos': patch
+---
+
+add commands to telegram

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -29,6 +29,7 @@ import { TelegramManager } from '@/managers/telegram'
 import { ayaPlugin } from '@/plugins/aya'
 import openaiPlugin from '@/plugins/openai'
 import { telegramPlugin } from '@/plugins/telegram'
+import { TelegramService } from '@/plugins/telegram/service'
 import { IKnowledgeService, IWalletService } from '@/services/interfaces'
 import { KnowledgeService } from '@/services/knowledge'
 import { WalletService } from '@/services/wallet'
@@ -97,8 +98,14 @@ export class Agent implements IAyaAgent {
 
   get telegram(): ITelegramManager {
     if (isNull(this.telegram_)) {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      this.telegram_ = new TelegramManager(this.runtime.getService('telegram' as ServiceTypeName))
+      const telegramService = this.runtime.getService<TelegramService>(
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        TelegramService.serviceType as ServiceTypeName
+      )
+      if (!telegramService) {
+        throw new Error('Telegram service not found')
+      }
+      this.telegram_ = new TelegramManager(telegramService)
     }
     return this.telegram_
   }

--- a/src/managers/interfaces.ts
+++ b/src/managers/interfaces.ts
@@ -1,4 +1,4 @@
-import { Content } from '@elizaos/core'
+import { TelegramContent } from '@/plugins/telegram/types'
 import { Context } from 'telegraf'
 
 export interface ITelegramManager {
@@ -6,7 +6,7 @@ export interface ITelegramManager {
 
   sendMessage(params: {
     chatId: number | string
-    content: Content
+    content: TelegramContent
     replyToMessageId?: number | undefined
-  }): Promise<void>
+  }): Promise<number | undefined>
 }

--- a/src/managers/interfaces.ts
+++ b/src/managers/interfaces.ts
@@ -8,5 +8,5 @@ export interface ITelegramManager {
     chatId: number | string
     content: Content
     replyToMessageId?: number | undefined
-  }): Promise<number>
+  }): Promise<void>
 }

--- a/src/managers/interfaces.ts
+++ b/src/managers/interfaces.ts
@@ -1,6 +1,9 @@
 import { Content } from '@elizaos/core'
+import { Context } from 'telegraf'
 
 export interface ITelegramManager {
+  registerCommand(command: string, handler: (ctx: Context) => Promise<void>): void
+
   sendMessage(params: {
     chatId: number | string
     content: Content

--- a/src/managers/telegram.ts
+++ b/src/managers/telegram.ts
@@ -1,9 +1,15 @@
 import { ITelegramManager } from '@/managers/interfaces'
 import { Content } from '@elizaos/core'
+import { Context } from 'telegraf'
 
 export class TelegramManager implements ITelegramManager {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(private readonly telegram: any) {}
+
+  registerCommand(command: string, handler: (ctx: Context) => Promise<void>): void {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    this.telegram.addCommandHandler(command, handler)
+  }
 
   async sendMessage(params: {
     chatId: number | string

--- a/src/managers/telegram.ts
+++ b/src/managers/telegram.ts
@@ -1,5 +1,5 @@
 import { ITelegramManager } from '@/managers/interfaces'
-import { Content } from '@elizaos/core'
+import { TelegramContent } from '@/plugins/telegram/types'
 import { Context } from 'telegraf'
 
 export class TelegramManager implements ITelegramManager {
@@ -13,17 +13,11 @@ export class TelegramManager implements ITelegramManager {
 
   async sendMessage(params: {
     chatId: number | string
-    content: Content
+    content: TelegramContent
     replyToMessageId?: number | undefined
-  }): Promise<number> {
+  }): Promise<void> {
     const { chatId, content, replyToMessageId } = params
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    const [message] = await this.telegram.messageManager.sendMessage(
-      chatId,
-      content,
-      replyToMessageId
-    )
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    return message.message_id
+    await this.telegram.messageManager.sendMessage(chatId, content, replyToMessageId)
   }
 }

--- a/src/managers/telegram.ts
+++ b/src/managers/telegram.ts
@@ -1,13 +1,12 @@
 import { ITelegramManager } from '@/managers/interfaces'
+import { TelegramService } from '@/plugins/telegram/service'
 import { TelegramContent } from '@/plugins/telegram/types'
 import { Context } from 'telegraf'
 
 export class TelegramManager implements ITelegramManager {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  constructor(private readonly telegram: any) {}
+  constructor(private readonly telegram: TelegramService) {}
 
   registerCommand(command: string, handler: (ctx: Context) => Promise<void>): void {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     this.telegram.addCommandHandler(command, handler)
   }
 
@@ -15,9 +14,13 @@ export class TelegramManager implements ITelegramManager {
     chatId: number | string
     content: TelegramContent
     replyToMessageId?: number | undefined
-  }): Promise<void> {
+  }): Promise<number | undefined> {
     const { chatId, content, replyToMessageId } = params
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    await this.telegram.messageManager.sendMessage(chatId, content, replyToMessageId)
+    const [message] = await this.telegram.messageManager.sendMessage(
+      chatId,
+      content,
+      replyToMessageId
+    )
+    return message.message_id ?? undefined
   }
 }

--- a/src/plugins/telegram/messageManager.ts
+++ b/src/plugins/telegram/messageManager.ts
@@ -601,7 +601,7 @@ export class MessageManager {
    */
   public async sendMessage(
     chatId: number | string,
-    content: Content,
+    content: TelegramContent,
     replyToMessageId?: number
   ): Promise<Message.CommonMessage[]> {
     try {

--- a/src/plugins/telegram/service.ts
+++ b/src/plugins/telegram/service.ts
@@ -37,6 +37,11 @@ export class TelegramService extends Service {
   public messageManager: MessageManager
   private knownChats: Set<string> = new Set<string>()
 
+  private commandHandlers: Map<string, (ctx: Context) => Promise<void>> = new Map<
+    string,
+    (ctx: Context) => Promise<void>
+  >()
+
   private syncedEntityIds: Set<string> = new Set<string>()
 
   /**
@@ -172,6 +177,9 @@ export class TelegramService extends Service {
     // Register the authorization middleware
     this.bot.use(this.authorizationMiddleware.bind(this))
 
+    // Register the command middleware
+    this.bot.use(this.commandMiddleware.bind(this))
+
     // Register the chat and entity management middleware
     this.bot.use(this.chatAndEntityMiddleware.bind(this))
   }
@@ -192,6 +200,29 @@ export class TelegramService extends Service {
       return
     }
     await next()
+  }
+
+  /**
+   * Command middleware - handles Telegram bot commands that start with '/'.
+   * This middleware checks if an incoming message is a command and executes the corresponding
+   * registered command handler if one exists.
+   *
+   * @param {Context} ctx - The context of the incoming update
+   * @param {Function} next - The function to call to proceed to the next middleware
+   * @returns {Promise<void>}
+   * @private
+   */
+  private async commandMiddleware(ctx: Context, next: () => Promise<void>): Promise<void> {
+    const text = ctx.text?.trim()
+    if (isNull(text) || text.length === 0 || !text.startsWith('/')) return next()
+
+    const command = text.split(' ')[0].slice(1)
+    if (command.length === 0) return next()
+
+    const commandHandler = this.commandHandlers.get(command)
+    if (isNull(commandHandler)) return next()
+
+    await commandHandler(ctx)
   }
 
   /**
@@ -277,6 +308,16 @@ export class TelegramService extends Service {
         console.error('Error handling reaction:', error)
       }
     })
+  }
+
+  /**
+   * Sets up a command handler for the bot.
+   * @param {string} command - The command to register.
+   * @param {Function} callback - The callback function to execute when the command is received.
+   * @returns {void}
+   */
+  public addCommandHandler(command: string, handler: (ctx: Context) => Promise<void>): void {
+    this.commandHandlers.set(command, handler)
   }
 
   /**

--- a/src/plugins/telegram/service.ts
+++ b/src/plugins/telegram/service.ts
@@ -37,10 +37,7 @@ export class TelegramService extends Service {
   public messageManager: MessageManager
   private knownChats: Set<string> = new Set<string>()
 
-  private commandHandlers: Map<string, (ctx: Context) => Promise<void>> = new Map<
-    string,
-    (ctx: Context) => Promise<void>
-  >()
+  private commandHandlers = new Map<string, (ctx: Context) => Promise<void>>()
 
   private syncedEntityIds: Set<string> = new Set<string>()
 


### PR DESCRIPTION
Allows agents to register telegram commands. Example:

```typescript
...

await agent.start()

agent.telegram.registerCommand('link', async (ctx) => {
  console.log('[TELEGRAM]: Received /link command from', chatId)
  agent.telegram.sendMessage({
    chatId: chatId,
    content: {
      text: "Let's get you set up with a new account",
      buttons: [
        {
          text: '🔑 Authenticate with Telegram',
          url: `${FRONTEND_URL}/onboarding`,
          kind: 'login'
        }
      ]
    }
  })
})

```