### PR TITLE
Add Telegram bot error handler

### DIFF
--- a/src/plugins/telegram/service.ts
+++ b/src/plugins/telegram/service.ts
@@ -50,6 +50,9 @@ export class TelegramService extends Service {
     console.log('📱 Constructing new TelegramService...')
     const botToken = runtime.getSetting('TELEGRAM_BOT_TOKEN') || process.env.TELEGRAM_BOT_TOKEN
     this.bot = new Telegraf(botToken)
+    this.bot.catch((err, ctx) => {
+      console.error('Telegram error for update', ctx.update, err)
+    })
     this.messageManager = new MessageManager(this.bot, this.runtime)
     console.log('✅ TelegramService constructor completed')
   }


### PR DESCRIPTION
## Summary
- catch Telegram errors during bot operation

## Testing
- `bun run lint` *(fails: ESLint couldn't find configuration)*
- `bun run type-check` *(fails: Cannot find type definition file for '@hapi/shot' and 'node')*